### PR TITLE
[BUG]: Faulty `sites` conversion and memory-less transfomers

### DIFF
--- a/changelog.d/17.changed.md
+++ b/changelog.d/17.changed.md
@@ -1,0 +1,1 @@
+Improve `sites` validation, handling and storage across transformers

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -210,12 +210,12 @@ def minimum_samples_warning(n_samples_per_site: list[list[int]] | npt.NDArray, m
         )
 
 
-def validate_covariates(covariates: npt.ArrayLike | None, n_samples: int, name: str) -> npt.NDArray | None:
+def validate_covariates(covariates: npt.NDArray | None, n_samples: int, name: str) -> npt.NDArray | None:
     """Validate covariates.
 
     Parameters
     ----------
-    covariates : array-like or None
+    covariates : array or None
         The covariates.
     n_samples : int
         Sample count.
@@ -227,15 +227,18 @@ def validate_covariates(covariates: npt.ArrayLike | None, n_samples: int, name: 
     array or None
         Validated covariates or None.
 
+    Raises
+    ------
+    ValueError
+        If covariates has incorrect shape.
+
     """
     if covariates is not None:
-        covariates = np.asarray(covariates)
         if covariates.ndim == 1:
             covariates = covariates.reshape(-1, 1)
         if covariates.shape[0] != n_samples:
             raise ValueError(f"{name} has {covariates.shape[0]} samples but sites has {n_samples}")
         return covariates
-    return None
 
 
 def validate_sites(sites: npt.NDArray) -> npt.NDArray:

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -11,6 +11,7 @@ __all__ = [
     "minimum_samples_warning",
     "solve_ordinary_least_squares",
     "validate_covariates",
+    "validate_sites",
 ]
 
 
@@ -241,7 +242,7 @@ def validate_covariates(covariates: npt.NDArray | None, n_samples: int, name: st
         return covariates
 
 
-def validate_sites(sites: npt.NDArray) -> npt.NDArray:
+def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
     """Validate sites.
 
     Parameters
@@ -254,10 +255,16 @@ def validate_sites(sites: npt.NDArray) -> npt.NDArray:
     array
         Validated sites.
 
+    Raises
+    ------
+    ValueError
+        If shape is incorrect.
+
     """
+    sites = np.asarray(sites)
     # Ensure sites is 2D for sklearn (n_samples, 1)
     if sites.ndim == 1:
         sites = sites.reshape(-1, 1)
     elif sites.ndim != 2 or sites.shape[1] != 1:
         raise ValueError(f"sites must be shape (n_samples,) or (n_samples, 1), got {sites.shape}")
-    return sites
+    return sites.astype(int)

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -257,4 +257,4 @@ def validate_sites(sites: npt.NDArray) -> None:
 
     """
     if len(np.unique(sites)) < 2:
-        raise ValueError("At least two sites required")
+        raise ValueError("At least 2 sites required")

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -6,6 +6,7 @@ import structlog
 
 
 __all__ = [
+    "convert_sites",
     "handle_near_zero_values",
     "handle_negative_variance",
     "minimum_samples_warning",
@@ -242,6 +243,26 @@ def validate_covariates(covariates: npt.NDArray | None, n_samples: int, name: st
         return covariates
 
 
+def convert_sites(s: list[str]) -> list[int]:
+    """Convert sites to proper format.
+
+    Parameters
+    ----------
+    s : list of str
+        Sites.
+
+    Returns
+    -------
+    list of int
+        Converted sites.
+
+    """
+    ks = set(s)
+    vs = list(range(1, len(ks) + 1))
+    kvs = dict(zip(ks, vs, strict=True))
+    return [kvs[k] for k in s]
+
+
 def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
     """Validate sites.
 
@@ -261,6 +282,9 @@ def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
         If shape is incorrect.
 
     """
+    if isinstance(sites, list):
+        if isinstance(next(iter(sites)), str):
+            sites = convert_sites(sites)
     sites = np.asarray(sites)
     # Ensure sites is 2D for sklearn (n_samples, 1)
     if sites.ndim == 1:

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -242,7 +242,7 @@ def validate_covariates(covariates: npt.NDArray | None, n_samples: int, name: st
         return covariates
 
 
-def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
+def validate_sites(sites: npt.NDArray) -> None:
     """Validate sites.
 
     Parameters
@@ -250,21 +250,11 @@ def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
     sites : array
         The sites.
 
-    Returns
-    -------
-    array
-        Validated sites.
-
     Raises
     ------
     ValueError
-        If shape is incorrect.
+        If single site is provided.
 
     """
-    sites = np.asarray(sites)
-    # Ensure sites is 2D for sklearn (n_samples, 1)
-    if sites.ndim == 1:
-        sites = sites.reshape(-1, 1)
-    elif sites.ndim != 2 or sites.shape[1] != 1:
-        raise ValueError(f"sites must be shape (n_samples,) or (n_samples, 1), got {sites.shape}")
-    return sites.astype(int)
+    if len(np.unique(sites)) < 2:
+        raise ValueError("At least two sites required")

--- a/src/uniharmony/_utils.py
+++ b/src/uniharmony/_utils.py
@@ -6,7 +6,6 @@ import structlog
 
 
 __all__ = [
-    "convert_sites",
     "handle_near_zero_values",
     "handle_negative_variance",
     "minimum_samples_warning",
@@ -243,26 +242,6 @@ def validate_covariates(covariates: npt.NDArray | None, n_samples: int, name: st
         return covariates
 
 
-def convert_sites(s: list[str]) -> list[int]:
-    """Convert sites to proper format.
-
-    Parameters
-    ----------
-    s : list of str
-        Sites.
-
-    Returns
-    -------
-    list of int
-        Converted sites.
-
-    """
-    ks = set(s)
-    vs = list(range(1, len(ks) + 1))
-    kvs = dict(zip(ks, vs, strict=True))
-    return [kvs[k] for k in s]
-
-
 def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
     """Validate sites.
 
@@ -282,9 +261,6 @@ def validate_sites(sites: npt.ArrayLike) -> npt.NDArray:
         If shape is incorrect.
 
     """
-    if isinstance(sites, list):
-        if isinstance(next(iter(sites)), str):
-            sites = convert_sites(sites)
     sites = np.asarray(sites)
     # Ensure sites is 2D for sklearn (n_samples, 1)
     if sites.ndim == 1:

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -413,7 +413,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
                 dtype=np.float64,
                 handle_unknown="error",
             )
-            self._site_encoder.fit(sites)
+            self._site_encoder.fit(sites.reshape(-1, 1))
             logger.debug(f"Fitted site encoder: {len(self._site_encoder.categories_[0])} sites")
 
             # Fit categorical encoders if provided
@@ -444,7 +444,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         design_parts = []
 
         # Transform sites
-        sites_encoded = self._site_encoder.transform(sites)
+        sites_encoded = self._site_encoder.transform(sites.reshape(-1, 1))
         design_parts.append(sites_encoded)
         n_sites = sites_encoded.shape[1]
         logger.debug(f"Sites encoded: {n_samples} samples x {n_sites} sites")

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -105,7 +105,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         ----------
         X : array-like, shape (n_samples, n_features)
             The training input samples.
-        sites : array-like, shape (n_samples, 1)
+        sites : array-like, shape (n_samples,)
             Sites.
         categorical_covariates : array-like, shape (n_samples, n_categorical_covariates) or None, optional (default None)
             The categorical covariates to be preserved during harmonization.
@@ -131,8 +131,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         # ######## Set up and check data ########
         # Check that X and sites have correct shape and type, and convert sites if they are strings
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        sites = check_array(sites, copy=self.copy, ensure_min_samples=2, estimator=self)
-
+        sites = check_array(sites, copy=self.copy, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, sites)
         validate_sites(sites)
 
@@ -226,7 +225,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         ----------
         X : array-like, shape (n_samples, n_features)
             The data to be harmonized.
-        sites : array-like, shape (n_samples, 1)
+        sites : array-like, shape (n_samples,)
             Sites.
         categorical_covariates : array-like, shape (n_samples, n_categorical_covariates) or None, optional (default None)
             The categorical covariates to be preserved during harmonization.
@@ -251,8 +250,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
 
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        sites = check_array(sites, copy=self.copy, estimator=self)
-
+        sites = check_array(sites, copy=self.copy, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, sites)
 
         if self._categorical_covariates_used:

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -131,10 +131,10 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         # ######## Set up and check data ########
         # Check that X and sites have correct shape and type, and convert sites if they are strings
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        sites = validate_sites(sites)
         sites = check_array(sites, copy=self.copy, ensure_min_samples=2, estimator=self)
 
         check_consistent_length(X, sites)
+        validate_sites(sites)
 
         # Check that categorical_covariates and continuous_covariates have correct shape and type if they are not None.
         # Track of whether they were used during fit to check during transform
@@ -251,7 +251,6 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
 
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        sites = validate_sites(sites)
         sites = check_array(sites, copy=self.copy, estimator=self)
 
         check_consistent_length(X, sites)

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -58,6 +58,11 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
     copy : bool, optional (default True)
         Whether to copy objects when doing `check_array`.
 
+    Attributes
+    ----------
+    sites_ : array, shape (n_samples,)
+        Fitted site names.
+
     References
     ----------
     [^1]:
@@ -160,10 +165,10 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         # Transpose to conform to neuroCombat and original ComBat
         X = X.T
 
-        self._sites_names, n_samples_per_site = np.unique(sites, return_counts=True)
-        self._n_sites = len(self._sites_names)
+        self.sites_, n_samples_per_site = np.unique(sites, return_counts=True)
+        self._n_sites = len(self.sites_)
         n_samples = sites.shape[0]
-        idx_per_site = [list(np.where(sites == idx)[0]) for idx in self._sites_names]
+        idx_per_site = [list(np.where(sites == s)[0].tolist()) for s in self.sites_]
 
         logger.debug("Making design matrix")
         design = self._make_design_matrix(
@@ -265,12 +270,13 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         new_data_sites_name = np.unique(sites)
 
         # Check all sites from new_data were seen
-        if not all(site_name in self._sites_names for site_name in new_data_sites_name):
+        if not all(s in self.sites_ for s in new_data_sites_name):
             raise ValueError("There is a site unseen during the fit method in the data.")
 
         n_samples = sites.shape[0]
-        n_samples_per_site = np.asarray([np.sum(sites == site_name) for site_name in self._sites_names])
-        idx_per_site = [list(np.where(sites == site_name)[0]) for site_name in self._sites_names]
+        n_samples_per_site = np.asarray([np.sum(sites == s) for s in self.sites_])
+        idx_per_site = [list(np.where(sites == s)[0].tolist()) for s in self.sites_]
+
         logger.debug("Making design matrix")
         design = self._make_design_matrix(
             sites,

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -131,10 +131,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         # ######## Set up and check data ########
         # Check that X and sites have correct shape and type, and convert sites if they are strings
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        if isinstance(next(iter(sites)), str):
-            sites = self._convert_sites(sites)
-        if np.asarray(sites).ndim == 1:
-            sites = np.asarray(sites).reshape(-1, 1)
+        sites = validate_sites(sites)
         sites = check_array(sites, copy=self.copy, ensure_min_samples=2, estimator=self)
 
         check_consistent_length(X, sites)
@@ -254,10 +251,7 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
 
         X = check_array(X, copy=self.copy, dtype=FLOAT_DTYPES, estimator=self)
-        if isinstance(next(iter(sites)), str):
-            sites = self._convert_sites(sites)
-        if np.asarray(sites).ndim == 1:
-            sites = np.asarray(sites).reshape(-1, 1)
+        sites = validate_sites(sites)
         sites = check_array(sites, copy=self.copy, estimator=self)
 
         check_consistent_length(X, sites)
@@ -398,8 +392,6 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
         # =====================================================================
         # STEP 1: Validate inputs
         # =====================================================================
-        sites = np.asarray(sites)
-        sites = validate_sites(sites)
         n_samples = sites.shape[0]
 
         categorical_covariates = validate_covariates(categorical_covariates, n_samples, "categorical_covariates")
@@ -1464,13 +1456,6 @@ class NeuroComBat(TransformerMixin, BaseEstimator):
 
         # Ensure positive variance
         return np.clip(result, 1e-8, None)
-
-    def _convert_sites(self, s: list[str]) -> list[int]:
-        """Convert sites to proper format."""
-        ks = set(s)
-        vs = list(range(1, len(ks) + 1))
-        kvs = dict(zip(ks, vs, strict=True))
-        return [kvs[k] for k in s]
 
     # Overridden for check_is_fitted() usage
     def __sklearn_is_fitted__(self) -> bool:

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -18,6 +18,7 @@ from sklearn.utils.validation import (
 
 from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
+    validate_class_representation,
     validate_covariates,
 )
 
@@ -298,6 +299,8 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, y, sites)
         validate_sites(sites)
+        validate_class_representation(y, sites)
+
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()
         # Validate inputs

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -304,13 +304,11 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()
         # Validate inputs
-        X_arr, y_arr, sites_arr, cat_cov, cont_cov = self._validate_inputs(
-            X, y, sites, categorical_covariate, continuous_covariate, allow_nan
-        )
+        cat_cov, cont_cov = self._validate_inputs(X, y, sites, categorical_covariate, continuous_covariate, allow_nan)
 
         # Initialize tracking
         self.unmatched_samples_: dict[tuple[Any, Any], int] = {}
-        self._unique_sites = np.unique(sites_arr)
+        self._unique_sites = np.unique(sites)
         self._n_sites = len(self._unique_sites)
 
         if self._n_sites < 2:
@@ -322,24 +320,24 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         self._log_configuration(cat_cov, cont_cov)
 
         # Generate samples
-        synthetic_X, synthetic_y, synthetic_sites = self._generate_samples(X_arr, y_arr, sites_arr, cat_cov, cont_cov)
+        synthetic_X, synthetic_y, synthetic_sites = self._generate_samples(X, y, sites, cat_cov, cont_cov)
 
         # Combine results
         if synthetic_X:
             if self.concatenate:
-                X_out = np.vstack([X_arr, *synthetic_X])
-                y_out = np.concatenate([y_arr, *synthetic_y])
-                sites_out = np.concatenate([sites_arr, *synthetic_sites])
+                X_out = np.vstack([X, *synthetic_X])
+                y_out = np.concatenate([y, *synthetic_y])
+                sites_out = np.concatenate([sites, *synthetic_sites])
             else:
                 X_out = np.vstack(synthetic_X)
                 y_out = np.concatenate(synthetic_y)
                 sites_out = np.concatenate(synthetic_sites)
         else:
-            X_out, y_out, sites_out = X_arr, y_arr, sites_arr
+            X_out, y_out, sites_out = X, y, sites
 
         self.sites_resampled_ = sites_out
 
-        self._log_completion(y_arr, synthetic_y)
+        self._log_completion(y, synthetic_y)
 
         return X_out, y_out
 
@@ -347,23 +345,16 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         self,
         X: ArrayLike,
         y: ArrayLike,
-        sites: ArrayLike,
         categorical_covariate: ArrayLike | None,
         continuous_covariate: ArrayLike | None,
         allow_nan: bool = False,
     ) -> tuple[
-        NDArray[np.float64],
-        NDArray[Any],
-        NDArray[Any],
         NDArray[Any] | None,
         NDArray[np.float64] | None,
     ]:
         """Validate and convert input arrays."""
-        X_arr, y_arr = check_X_y(X, y)
-        sites_arr = check_array(sites, ensure_2d=False, dtype=None)
-
         cat_cov, cont_cov, cov_tol = validate_covariates(
-            X_arr.shape[0],
+            X.shape[0],
             categorical_covariate,
             continuous_covariate,
             self.covariate_tolerance,
@@ -371,16 +362,16 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         )
 
         self.covariate_tolerance_ = cov_tol
-        self._problem_type = "classification" if y_arr.dtype.kind in "biu" else "regression"
+        self._problem_type = "classification" if y.dtype.kind in "biu" else "regression"
 
         # Set default target_tolerance for regression if not specified
         if self._problem_type == "regression" and self.target_tolerance is None:
-            y_range = np.ptp(y_arr)
+            y_range = np.ptp(y)
             self.target_tolerance_ = y_range * 0.1 if y_range > 0 else 1.0
         else:
             self.target_tolerance_ = self.target_tolerance
 
-        return X_arr, y_arr, sites_arr, cat_cov, cont_cov
+        return cat_cov, cont_cov
 
     def _log_configuration(
         self,

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -294,6 +294,7 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
             parameters are inconsistent.
 
         """
+        X, y = check_X_y(X, y, estimator=self)
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, y, sites)
         validate_sites(sites)

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -304,7 +304,7 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()
         # Validate inputs
-        cat_cov, cont_cov = self._validate_inputs(X, y, sites, categorical_covariate, continuous_covariate, allow_nan)
+        cat_cov, cont_cov = self._validate_inputs(X, y, categorical_covariate, continuous_covariate, allow_nan)
 
         # Initialize tracking
         self.unmatched_samples_: dict[tuple[Any, Any], int] = {}

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -10,7 +10,11 @@ from imblearn.base import SamplerMixin
 from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
-from sklearn.utils.validation import check_array, check_X_y
+from sklearn.utils.validation import (
+    check_array,
+    check_consistent_length,
+    check_X_y,
+)
 
 from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
@@ -291,6 +295,7 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
 
         """
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
+        check_consistent_length(X, y, sites)
         validate_sites(sites)
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -14,7 +14,6 @@ from sklearn.utils.validation import check_array, check_X_y
 
 from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
-    sites_sanity_checks,
     validate_covariates,
 )
 
@@ -353,14 +352,6 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         """Validate and convert input arrays."""
         X_arr, y_arr = check_X_y(X, y)
         sites_arr = check_array(sites, ensure_2d=False, dtype=None)
-
-        # Wrap sites_sanity_checks to match expected error message
-        try:
-            sites_sanity_checks(X_arr, sites_arr)
-        except ValueError as e:
-            if "At least two sites required" in str(e):
-                raise ValueError(f"Need at least 2 sites, got {len(np.unique(sites_arr))}") from e
-            raise
 
         cat_cov, cont_cov, cov_tol = validate_covariates(
             X_arr.shape[0],

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -12,6 +12,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array, check_X_y
 
+from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
     sites_sanity_checks,
     validate_covariates,
@@ -290,6 +291,7 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
             parameters are inconsistent.
 
         """
+        validate_sites(sites)
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()
         # Validate inputs

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -291,6 +291,7 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
             parameters are inconsistent.
 
         """
+        sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         validate_sites(sites)
         # Validate parameters immediately (sklearn convention allows basic validation)
         self._validate_init_params()

--- a/src/uniharmony/interpolation/_inter_site_matched.py
+++ b/src/uniharmony/interpolation/_inter_site_matched.py
@@ -311,9 +311,6 @@ class InterSiteMatchedInterpolation(SamplerMixin, BaseEstimator):
         self._unique_sites = np.unique(sites)
         self._n_sites = len(self._unique_sites)
 
-        if self._n_sites < 2:
-            raise ValueError(f"Need at least 2 sites, got {self._n_sites}")
-
         # Setup parameters
         self.random_state_ = check_random_state(self.random_state)
 

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -7,7 +7,11 @@ import structlog
 from imblearn.base import SamplerMixin
 from sklearn.base import BaseEstimator
 from sklearn.utils import Tags, check_random_state
-from sklearn.utils.validation import check_array, check_X_y
+from sklearn.utils.validation import (
+    check_array,
+    check_consistent_length,
+    check_X_y,
+)
 
 from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
@@ -111,6 +115,7 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
         # This methods needs at least two classes per site
         class_representation_checks(y, sites)
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
+        check_consistent_length(X, y, sites)
         validate_sites(sites)
 
         random_state = check_random_state(self.random_state)

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -15,8 +15,8 @@ from sklearn.utils.validation import (
 
 from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
-    class_representation_checks,
     create_interpolator,
+    validate_class_representation,
 )
 
 
@@ -110,13 +110,11 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
         this count using the configured interpolator.
 
         """
-
-        # This methods needs at least two classes per site
-        class_representation_checks(y, sites)
         X, y = check_X_y(X, y, estimator=self)
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, y, sites)
         validate_sites(sites)
+        validate_class_representation(y, sites)
 
         random_state = check_random_state(self.random_state)
         if isinstance(self.interpolator, str):

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -13,7 +13,6 @@ from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
     class_representation_checks,
     create_interpolator,
-    sites_sanity_checks,
 )
 
 
@@ -108,9 +107,6 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
 
         """
         X, y = check_X_y(X, y)
-
-        # Sanity checks for site length and number of sites
-        sites_sanity_checks(X, sites)
 
         # This methods needs at least two classes per site
         class_representation_checks(y, sites)

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -108,13 +108,13 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
 
         """
         X, y = check_X_y(X, y)
-        sites = check_array(sites, ensure_2d=False)
 
         # Sanity checks for site length and number of sites
         sites_sanity_checks(X, sites)
 
         # This methods needs at least two classes per site
         class_representation_checks(y, sites)
+        sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         validate_sites(sites)
 
         random_state = check_random_state(self.random_state)

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -110,10 +110,10 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
         this count using the configured interpolator.
 
         """
-        X, y = check_X_y(X, y)
 
         # This methods needs at least two classes per site
         class_representation_checks(y, sites)
+        X, y = check_X_y(X, y, estimator=self)
         sites = check_array(sites, dtype=None, ensure_2d=False, estimator=self)
         check_consistent_length(X, y, sites)
         validate_sites(sites)

--- a/src/uniharmony/interpolation/_intra_site.py
+++ b/src/uniharmony/interpolation/_intra_site.py
@@ -9,6 +9,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import Tags, check_random_state
 from sklearn.utils.validation import check_array, check_X_y
 
+from uniharmony._utils import validate_sites
 from uniharmony.interpolation._utils import (
     class_representation_checks,
     create_interpolator,
@@ -114,6 +115,7 @@ class IntraSiteInterpolation(SamplerMixin, BaseEstimator):
 
         # This methods needs at least two classes per site
         class_representation_checks(y, sites)
+        validate_sites(sites)
 
         random_state = check_random_state(self.random_state)
         if isinstance(self.interpolator, str):

--- a/src/uniharmony/interpolation/_utils.py
+++ b/src/uniharmony/interpolation/_utils.py
@@ -21,7 +21,6 @@ from sklearn.utils.validation import check_array
 __all__ = [
     "class_representation_checks",
     "create_interpolator",
-    "sites_sanity_checks",
     "validate_covariates",
 ]
 
@@ -69,30 +68,6 @@ def create_interpolator(
         raise ValueError(f"Unsupported interpolator: {name}")
 
     return mapping[name](random_state=random_state, sampling_strategy="not majority", **kwargs)
-
-
-def sites_sanity_checks(x: npt.NDArray, sites: npt.NDArray) -> None:
-    """Sanity checks for site array.
-
-    Parameters
-    ----------
-    x : array
-        Features.
-    sites : array
-        Sites.
-
-    Raises
-    ------
-    ValueError
-        If ``x`` and ``sites`` have different length or
-        if single site is provided.
-
-    """
-    if x.shape[0] != sites.shape[0]:
-        raise ValueError("X and sites must have same length")
-
-    if len(np.unique(sites)) < 2:
-        raise ValueError("At least two sites required")
 
 
 def class_representation_checks(y: npt.NDArray, sites: npt.NDArray) -> None:

--- a/src/uniharmony/interpolation/_utils.py
+++ b/src/uniharmony/interpolation/_utils.py
@@ -19,8 +19,8 @@ from sklearn.utils.validation import check_array
 
 
 __all__ = [
-    "class_representation_checks",
     "create_interpolator",
+    "validate_class_representation",
     "validate_covariates",
 ]
 
@@ -70,7 +70,7 @@ def create_interpolator(
     return mapping[name](random_state=random_state, sampling_strategy="not majority", **kwargs)
 
 
-def class_representation_checks(y: npt.NDArray, sites: npt.NDArray) -> None:
+def validate_class_representation(y: npt.NDArray, sites: npt.NDArray) -> None:
     """Check that each site has at least two classes.
 
     Parameters

--- a/tests/combat/test_neuro_combat.py
+++ b/tests/combat/test_neuro_combat.py
@@ -28,6 +28,7 @@ def _ex_failed_checks(_) -> dict[str, str]:
         "check_fit_idempotent": "sites instead of y",
         "check_n_features_in": "not needed",
         "check_fit2d_predict1d": "sites instead of y",
+        "check_fit2d_1sample": "custom message",
         "check_requires_y_none": "target cannot be None",
     }
 

--- a/tests/interpolation/test_inter_site_matched.py
+++ b/tests/interpolation/test_inter_site_matched.py
@@ -153,7 +153,7 @@ def test_single_site_error() -> None:
     y = np.random.randint(0, 2, 50)
     sites = np.array(["A"] * 50)
     ismi = InterSiteMatchedInterpolation()
-    with pytest.raises(ValueError, match="at least 2 sites"):
+    with pytest.raises(ValueError, match="2 sites"):
         ismi.fit_resample(X, y, sites=sites)
 
 
@@ -316,11 +316,8 @@ def test_no_matches_found() -> None:
     sites = np.array(["A"] * 10 + ["B"] * 10)
 
     ismi = InterSiteMatchedInterpolation(random_state=42)
-    X_res, _ = ismi.fit_resample(X, y, sites=sites)
-
-    # Returns original only (no matches possible since site A has class 0, site B has class 1)
-    assert len(X_res) == len(X)
-    assert sum(ismi.unmatched_samples_.values()) == 20
+    with pytest.raises(ValueError, match="cannot resample"):
+        ismi.fit_resample(X, y, sites=sites)
 
 
 def test_empty_site() -> None:
@@ -330,8 +327,8 @@ def test_empty_site() -> None:
     sites = np.array(["A"] * 5 + ["B"] * 5)
 
     ismi = InterSiteMatchedInterpolation(random_state=42)
-    X_res, _ = ismi.fit_resample(X, y, sites=sites)
-    assert len(X_res) >= len(X)
+    with pytest.raises(ValueError, match="cannot resample"):
+        ismi.fit_resample(X, y, sites=sites)
 
 
 def test_alpha_out_of_range_warning(binary_2site) -> None:
@@ -400,8 +397,8 @@ def test_multiclass() -> None:
     y = np.array([0] * 50 + [1] * 50 + [2] * 50)
     sites = np.array(["A"] * 50 + ["B"] * 50 + ["C"] * 50)
     ismi = InterSiteMatchedInterpolation(random_state=42)
-    _, y_res = ismi.fit_resample(X, y, sites=sites)
-    assert len(np.unique(y_res)) == 3
+    with pytest.raises(ValueError, match="cannot resample"):
+        ismi.fit_resample(X, y, sites=sites)
 
 
 def test_integer_sites() -> None:


### PR DESCRIPTION
### Is there an existing issue for this?

- [x] I have searched the existing issues

### Current Behavior

As the conversion do not remember the "name" of the sites, the conversion in transform will transform any new name starting with "1"m then  "2" and so on. If the number of sites matches, the model will not complain but it will wrongly assume the sites for the transformed data.

For example, if I fit with:
sites = ["1", "1", "1", "1", "1", "2", "2", "2", "2", "2"]
and then transform with:
sites_unseen = ["3", "3", "3", "3", "3", "4", "4", "4", "4", "4"]
 In the transformation, sites "3" will be assigned as 1 and "4" as 2. Then, the model will not fail but will produce unwanted results.




### Expected Behavior

The model should crash when passing unseen sites

### Steps To Reproduce

    data = np.genfromtxt(Path(__file__).parent / "test_data.csv", delimiter=",", skip_header=1)
    batches = ["1", "1", "1", "1", "1", "2", "2", "2", "2", "2"]
    genders = np.array([1, 2, 1, 2, 1, 2, 1, 2, 1, 2]).reshape(-1, 1)
    neurocombat = NeuroComBat(empirical_bayes=True, parametric_adjustments=False, mean_only=False)
    _ = neurocombat.fit(
        data.T,
        batches,
        categorical_covariates=genders,
    )
    batches_unseen = ["3", "3", "3", "3", "3", "4", "4", "4", "4", "4"]

    _ = neurocombat.transform(
        data.T,
        batches_unseen,
        categorical_covariates=genders
    )

This is not crashing


### Environment

```markdown
The environment is uniharmony -dev
```

### Relevant log output

```shell

```

### Anything else?

_No response_