### PR TITLE
Remove `copy` parameter from ComBat-based methods

### DIFF
--- a/changelog.d/65.changed.md
+++ b/changelog.d/65.changed.md
@@ -1,0 +1,1 @@
+Remove `copy` parameter from ComBat-based methods and change its default from True to False

--- a/src/uniharmony/combat/_base.py
+++ b/src/uniharmony/combat/_base.py
@@ -24,7 +24,7 @@ class BaseComBat(DesignMatrixMixin, StandardizationMixin, LocationAndScaleMixin,
         self,
         X: npt.ArrayLike,
         sites: npt.ArrayLike,
-        copy: bool = True,
+        copy: bool = False,
         estimator: type["BaseComBat"] | None = None,
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Check X and sites.
@@ -35,7 +35,7 @@ class BaseComBat(DesignMatrixMixin, StandardizationMixin, LocationAndScaleMixin,
             Input data.
         sites : array-like, shape (n_samples,)
             Sites.
-        copy : bool, optional (default True)
+        copy : bool, optional (default False)
             Whether to copy objects when doing `check_array`.
         estimator : estimator instance, optional (default None)
             If passed, include the name of the estimator in warning messages.

--- a/src/uniharmony/combat/_combat_gam.py
+++ b/src/uniharmony/combat/_combat_gam.py
@@ -40,8 +40,6 @@ class ComBatGAM(BaseComBat):
         Whether to perform parametric adjustments.
     mean_only : bool, optional (default False)
         Whether to only adjust mean (no scaling).
-    copy : bool, optional (default True)
-        Whether to copy objects when doing `check_array`.
 
     Attributes
     ----------
@@ -62,12 +60,10 @@ class ComBatGAM(BaseComBat):
         empirical_bayes: bool = True,
         parametric_adjustments: bool = True,
         mean_only: bool = False,
-        copy: bool = True,
     ) -> None:
         self.empirical_bayes = empirical_bayes
         self.parametric_adjustments = parametric_adjustments
         self.mean_only = mean_only
-        self.copy = copy
 
     def fit(
         self,
@@ -119,7 +115,7 @@ class ComBatGAM(BaseComBat):
         logger.debug("Fitting")
 
         # Validate input
-        X, sites = self._check_X_sites(X, sites, copy=self.copy, estimator=self)
+        X, sites = self._check_X_sites(X, sites, estimator=self)
         validate_sites(sites)
 
         # Check smooth_covariates and its bounds if passed
@@ -268,7 +264,7 @@ class ComBatGAM(BaseComBat):
 
         # Validate input
         check_is_fitted(self)
-        X, sites = self._check_X_sites(X, sites, copy=self.copy, estimator=self)
+        X, sites = self._check_X_sites(X, sites, estimator=self)
 
         smooth_covariates = check_array(smooth_covariates, dtype=FLOAT_DTYPES, estimator=self)
 

--- a/src/uniharmony/combat/_neuro_combat.py
+++ b/src/uniharmony/combat/_neuro_combat.py
@@ -44,8 +44,6 @@ class NeuroComBat(BaseComBat):
         Whether to perform parametric adjustments.
     mean_only : bool, optional (default False)
         Whether to only adjust mean (no scaling).
-    copy : bool, optional (default True)
-        Whether to copy objects when doing `check_array`.
 
     Attributes
     ----------
@@ -73,12 +71,10 @@ class NeuroComBat(BaseComBat):
         empirical_bayes: bool = True,
         parametric_adjustments: bool = True,
         mean_only: bool = False,
-        copy: bool = True,
     ) -> None:
         self.empirical_bayes = empirical_bayes
         self.parametric_adjustments = parametric_adjustments
         self.mean_only = mean_only
-        self.copy = copy
 
     def fit(
         self,
@@ -121,7 +117,7 @@ class NeuroComBat(BaseComBat):
         logger.debug("Fitting")
 
         # Validate input
-        X, sites = self._check_X_sites(X, sites, copy=self.copy, estimator=self)
+        X, sites = self._check_X_sites(X, sites, estimator=self)
         validate_sites(sites)
 
         # Check that categorical_covariates and continuous_covariates have correct shape and type if they are not None.
@@ -222,7 +218,7 @@ class NeuroComBat(BaseComBat):
 
         # Validate input
         check_is_fitted(self)
-        X, sites = self._check_X_sites(X, sites, copy=self.copy, estimator=self)
+        X, sites = self._check_X_sites(X, sites, estimator=self)
 
         if self._categorical_covariates_used:
             categorical_covariates = check_array(categorical_covariates, dtype=None, estimator=self)


### PR DESCRIPTION
This PR removes the `copy` parameter from ComBat-based methods and changes the default value of it in `BaseComBat._check_X_sites`.