### PR TITLE
Add multisite site filtering helper

### DIFF
--- a/changelog.d/44.added.md
+++ b/changelog.d/44.added.md
@@ -1,0 +1,1 @@
+Add a helper to filter multisite datasets by included or excluded site labels.

--- a/docs/api/datasets/filter_data_by_site.md
+++ b/docs/api/datasets/filter_data_by_site.md
@@ -1,0 +1,5 @@
+# filter_data_by_site
+
+```{eval-rst}
+.. autofunction:: uniharmony.datasets.filter_data_by_site
+```

--- a/docs/api/datasets/index.md
+++ b/docs/api/datasets/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 1
 make_multisite_classification
+filter_data_by_site
 load_mareos
 load_on_harmony
 download_bids_dataset

--- a/src/uniharmony/datasets/__init__.pyi
+++ b/src/uniharmony/datasets/__init__.pyi
@@ -4,6 +4,7 @@ __all__ = [
     "clean_tmp",
     "download_ONharmony",
     "download_bids_dataset",
+    "filter_data_by_site",
     "get_multisite_data_statistics",
     "list_available_files",
     "list_available_possibilities_onharmony",
@@ -24,3 +25,4 @@ from ._load_onharmony_structural_features import load_onharmony_structural_featu
 from ._make_covariates import Covariate, CovariateSiteDistribution
 from ._make_multisite_classification import make_multisite_classification
 from ._multisite_data_characterization import get_multisite_data_statistics, print_statistics_summary
+from ._multisite_data_processing import filter_data_by_site

--- a/src/uniharmony/datasets/_multisite_data_processing.py
+++ b/src/uniharmony/datasets/_multisite_data_processing.py
@@ -1,0 +1,112 @@
+"""Process multisite datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.utils.validation import check_array, check_consistent_length
+
+
+__all__ = [
+    "filter_data_by_site",
+]
+
+SiteLabel = str | int | float
+SiteSelection = SiteLabel | Iterable[SiteLabel] | np.ndarray | pd.Series | None
+DataLike = pd.DataFrame | pd.Series | np.ndarray | list[Any]
+
+
+def filter_data_by_site(
+    X: DataLike,
+    y: DataLike,
+    sites: DataLike,
+    include_sites: SiteSelection = None,
+    exclude_sites: SiteSelection = None,
+) -> tuple[DataLike, DataLike, DataLike]:
+    """Filter multisite data by site labels.
+
+    Parameters
+    ----------
+    X : pandas.DataFrame, pandas.Series, numpy.ndarray or list
+        Feature data with one row per sample.
+    y : pandas.DataFrame, pandas.Series, numpy.ndarray or list
+        Target labels with one row per sample.
+    sites : pandas.DataFrame, pandas.Series, numpy.ndarray or list
+        Site labels with one row per sample.
+    include_sites : scalar, iterable or None, default=None
+        Site labels to keep. When ``None``, all sites are initially kept.
+    exclude_sites : scalar, iterable or None, default=None
+        Site labels to remove. Exclusions are applied after inclusions.
+
+    Returns
+    -------
+    X_filtered : same type as X for pandas inputs, otherwise numpy.ndarray
+        Filtered feature data.
+    y_filtered : same type as y for pandas inputs, otherwise numpy.ndarray
+        Filtered target labels.
+    sites_filtered : same type as sites for pandas inputs, otherwise numpy.ndarray
+        Filtered site labels.
+
+    Raises
+    ------
+    ValueError
+        If ``X``, ``y`` and ``sites`` do not have consistent lengths, or if
+        ``sites`` is not one-dimensional.
+
+    Examples
+    --------
+    >>> X_filtered, y_filtered, sites_filtered = filter_data_by_site(
+    ...     X,
+    ...     y,
+    ...     sites,
+    ...     include_sites=["site_a", "site_b"],
+    ...     exclude_sites="site_b",
+    ... )
+
+    """
+    check_consistent_length(X, y, sites)
+    sites_array = check_array(sites, dtype=None, ensure_2d=False)
+
+    if sites_array.ndim != 1:
+        msg = "sites must be one-dimensional."
+        raise ValueError(msg)
+
+    mask = np.ones(sites_array.shape[0], dtype=bool)
+    include_values = _normalize_site_selection(include_sites)
+    exclude_values = _normalize_site_selection(exclude_sites)
+
+    if include_values is not None:
+        mask &= np.isin(sites_array, include_values)
+
+    if exclude_values is not None:
+        mask &= ~np.isin(sites_array, exclude_values)
+
+    return _filter_rows(X, mask), _filter_rows(y, mask), _filter_rows(sites, mask)
+
+
+def _normalize_site_selection(selection: SiteSelection) -> np.ndarray | None:
+    """Return a one-dimensional array of selected site labels."""
+    if selection is None:
+        return None
+
+    if isinstance(selection, str) or np.isscalar(selection):
+        values = np.asarray([selection], dtype=object)
+    else:
+        values = np.asarray(list(selection), dtype=object)
+
+    if values.ndim != 1:
+        msg = "Site selections must be scalar labels or one-dimensional collections of labels."
+        raise ValueError(msg)
+
+    return values
+
+
+def _filter_rows(data: DataLike, mask: np.ndarray) -> DataLike:
+    """Filter rows while preserving pandas containers."""
+    if isinstance(data, pd.DataFrame | pd.Series):
+        return data.iloc[mask]
+
+    return np.asarray(data)[mask]

--- a/tests/datasets/test_multisite_data_processing.py
+++ b/tests/datasets/test_multisite_data_processing.py
@@ -1,0 +1,86 @@
+"""Test suite for multisite data processing functions."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from uniharmony.datasets import filter_data_by_site
+
+
+def test_filter_data_by_site_includes_requested_sites() -> None:
+    """Filter numpy data to the requested sites."""
+    X = np.arange(12).reshape(6, 2)
+    y = np.array([0, 1, 0, 1, 0, 1])
+    sites = np.array(["site_a", "site_b", "site_a", "site_c", "site_b", "site_a"])
+
+    X_filtered, y_filtered, sites_filtered = filter_data_by_site(X, y, sites, include_sites=["site_a", "site_c"])
+
+    np.testing.assert_array_equal(X_filtered, X[[0, 2, 3, 5]])
+    np.testing.assert_array_equal(y_filtered, y[[0, 2, 3, 5]])
+    np.testing.assert_array_equal(sites_filtered, sites[[0, 2, 3, 5]])
+
+
+def test_filter_data_by_site_excludes_requested_sites() -> None:
+    """Exclude numpy rows that belong to a site."""
+    X = np.arange(12).reshape(6, 2)
+    y = np.array([0, 1, 0, 1, 0, 1])
+    sites = np.array(["site_a", "site_b", "site_a", "site_c", "site_b", "site_a"])
+
+    X_filtered, y_filtered, sites_filtered = filter_data_by_site(X, y, sites, exclude_sites="site_b")
+
+    np.testing.assert_array_equal(X_filtered, X[[0, 2, 3, 5]])
+    np.testing.assert_array_equal(y_filtered, y[[0, 2, 3, 5]])
+    np.testing.assert_array_equal(sites_filtered, sites[[0, 2, 3, 5]])
+
+
+def test_filter_data_by_site_applies_exclusions_after_inclusions() -> None:
+    """Apply exclusions after the include list."""
+    X = np.arange(12).reshape(6, 2)
+    y = np.array([0, 1, 0, 1, 0, 1])
+    sites = np.array(["site_a", "site_b", "site_a", "site_c", "site_b", "site_a"])
+
+    X_filtered, y_filtered, sites_filtered = filter_data_by_site(
+        X,
+        y,
+        sites,
+        include_sites=["site_a", "site_b"],
+        exclude_sites=["site_b"],
+    )
+
+    np.testing.assert_array_equal(X_filtered, X[[0, 2, 5]])
+    np.testing.assert_array_equal(y_filtered, y[[0, 2, 5]])
+    np.testing.assert_array_equal(sites_filtered, sites[[0, 2, 5]])
+
+
+def test_filter_data_by_site_preserves_pandas_containers() -> None:
+    """Preserve pandas data types and indexes when filtering."""
+    index = ["sample_0", "sample_1", "sample_2", "sample_3"]
+    X = pd.DataFrame({"feature_0": [0.1, 0.2, 0.3, 0.4], "feature_1": [1.1, 1.2, 1.3, 1.4]}, index=index)
+    y = pd.Series([0, 1, 0, 1], index=index, name="target")
+    sites = pd.Series(["site_a", "site_b", "site_a", "site_c"], index=index, name="site")
+
+    X_filtered, y_filtered, sites_filtered = filter_data_by_site(X, y, sites, include_sites="site_a")
+
+    pd.testing.assert_frame_equal(X_filtered, X.iloc[[0, 2]])
+    pd.testing.assert_series_equal(y_filtered, y.iloc[[0, 2]])
+    pd.testing.assert_series_equal(sites_filtered, sites.iloc[[0, 2]])
+
+
+def test_filter_data_by_site_rejects_inconsistent_lengths() -> None:
+    """Reject inputs that do not describe the same number of samples."""
+    X = np.arange(8).reshape(4, 2)
+    y = np.array([0, 1, 0])
+    sites = np.array(["site_a", "site_b", "site_a", "site_c"])
+
+    with pytest.raises(ValueError, match="inconsistent numbers of samples"):
+        filter_data_by_site(X, y, sites, include_sites="site_a")
+
+
+def test_filter_data_by_site_rejects_two_dimensional_sites() -> None:
+    """Reject site labels that are not one-dimensional."""
+    X = np.arange(8).reshape(4, 2)
+    y = np.array([0, 1, 0, 1])
+    sites = np.array([["site_a"], ["site_b"], ["site_a"], ["site_c"]])
+
+    with pytest.raises(ValueError, match="sites must be one-dimensional"):
+        filter_data_by_site(X, y, sites, include_sites="site_a")


### PR DESCRIPTION
## Summary
- Add `filter_data_by_site` for selecting or excluding samples by site label.
- Preserve pandas DataFrame/Series inputs while returning NumPy arrays for array-like inputs.
- Export the helper, add API docs, and include a towncrier fragment.

Fixes #44

## Verification
- uv run --with pytest pytest tests/datasets/test_multisite_data_processing.py -q
- uv run --extra dev tox -e ruff
- uv run --extra dev tox -e changelog